### PR TITLE
Quoted identifier fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2]
+
+- Updated the command that executes the sql scripts to include the -I option, which was previously enabled by default.
+
 ## [1.1.1]
 
 - Updated parsing connection string to allow more formats while solving a bug where the parsed username/id wasn't used at all.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ FROM inforitnl/mssql-seed
 COPY ./seed-files .
 ```
 
+#### Note
+
+For the scripts that are ran the following option is enabled by default: `sqlcmd -I`.
+This sets the `SET QUOTED_IDENTIFIER` connection option to `ON`. By default, it's set to `OFF`. For more information, see [SET QUOTED_IDENTIFIER (Transact-SQL)](https://learn.microsoft.com/en-us/sql/t-sql/statements/set-quoted-identifier-transact-sql?view=sql-server-ver16).
+
 ### use your container in compose files
 
 ```sh
@@ -30,10 +35,7 @@ services:
       SQL_DATABASE: "database-to-seed"
 
     extra_hosts:
-      # linux/mac users: next line only works for you.
-      host.docker.internal: 172.17.0.1
-      # windows users: comment out next line and comment previous line.
-      #host.docker.internal: 192.168.65.2
+      - host.docker.internal:host-gateway
 
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mssql-seed-container",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "[![logo](./logo.jpg)](https://inforit.nl)",
     "main": "Dockerfile",
     "scripts": {

--- a/scripts/mssql-seed.sh
+++ b/scripts/mssql-seed.sh
@@ -35,7 +35,7 @@ fi
 # Execute each file in working dir in aphabetical order.
 for currentFile in $(ls | sort | grep .sql); do
     echo "Processing ${currentFile}"
-    sqlcmd \
+    sqlcmd -I\
         -S "$SQL_HOST,$SQL_PORT" \
         -U "$SQL_USERNAME" \
         -P "$SQL_PASSWORD" \


### PR DESCRIPTION
Updated the command that executes the sql scripts to include the -I option, which was previously enabled by default.